### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -44,7 +44,7 @@ concurrency:
 
 jobs:
   bootstrap:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write        # we need to commit back to the repo
       actions: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: "⬇️ Checkout"
         uses: actions/checkout@v5


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.